### PR TITLE
Fix mixed content errors when site served over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>CAPQ</title>
-  <link href='http://fonts.googleapis.com/css?family=Quattrocento' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Quattrocento+Sans' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Quattrocento' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Quattrocento+Sans' rel='stylesheet' type='text/css'>
   <style type="text/css">code{white-space: pre;}</style>
   <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -14,14 +14,16 @@
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="style/style.css">
-  <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+  <script type="text/javascript" async
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  </script>
   <script>
   	var hash = window.location.hash.substring(1);
   	if (hash)
   	{
   		window.location.href = "q/"+hash+".html";
   	}
-  	
+
   </script>
 
 
@@ -44,7 +46,7 @@
 Author: Riccardo Antonelli <riccardo.antonelli@hotmail.it>
 Date:   Mon Nov 16 12:37:31 2015 +0100
 	</div>--!>
-		
+
 <p>Everyone gets bored of always answering the same questions over and over again. It's normal. Especially if it's Physics. That's why we have FAQs. But next to the <em>always</em> asked questions, there are also the <em>often</em> asked, those who just can not make it to big FAQs but really are popular enough to annoy the answerer, helplessly scrolling for new adventures in a sea of d&eacute;j&agrave;-vus.</p>
 
 <p>This is not a definitive FAQ, nor is it necessarily a good FAQ, it's just my FAQ. It's shamelessly skewed towards my view of the physical world. It is also very inconsistent in the level requested of the reader. Typically, I'd just assume the minimal background needed for the answer to be a pleasurable conversation, neither a patronizing poem nor a bored review.</p>
@@ -52,7 +54,7 @@ Date:   Mon Nov 16 12:37:31 2015 +0100
 <p>You can contribute if you want! Check the <a href="https://github.com/rantonels/capq">README at the Github project page</a> or just <a href="https://reddit.com/u/rantonels">hit me up on Reddit</a>.</p>
 
 <!--<p><small>(The stylesheet for this webpage is markdown5.css by jasonm23 (<a href="https://github.com/jasonm23/markdown-css-themes">Github</a>))</small></p>--!>
-		
+
 </div>
 <div class="col-md-4 col-xs-12 downloadpanel">
 		<h3><i class="fa fa-arrow-down"></i> Download .pdf</h3>
@@ -63,7 +65,7 @@ Date:   Mon Nov 16 12:37:31 2015 +0100
 
 <div class="col-md-4 hidden-xs buttons text-center">
 
-	
+
 	<a href="https://github.com/rantonels/capq"><i class="fa fa-github-alt"></i></a>
 	<a href="https://www.reddit.com/r/AskPhysics/comments/3c0feo/meta_im_making_a_physics_faq/"><i class="fa fa-reddit"></i></a>
 	<a href="https://rantonels.github.io"><i class="fa fa-home"></i></a>


### PR DESCRIPTION
When viewing the site over HTTPS, LaTeX fails to render.

Changes:
- Google fonts now requested over HTTPS
- [MathJax's self-hosted CDN was shut down in 2017](https://www.mathjax.org/cdn-shutting-down/) and is replaced with the suggested cdnjs mirror.  Also fixed to serve over HTTPS.